### PR TITLE
Workaround kadasitemlayer

### DIFF
--- a/kadasrouting/gui/navigationpanel.py
+++ b/kadasrouting/gui/navigationpanel.py
@@ -9,26 +9,11 @@ from PyQt5 import uic
 import re
 from zipfile import ZipFile
 
-from PyQt5.QtGui import (
-    QPixmap,
-    QTransform,
-    QPainter,
-    QColor
-)
+from PyQt5.QtGui import QPixmap, QTransform, QPainter, QColor
 
-from PyQt5.QtCore import (
-    Qt,
-    QSize,
-    QSettings,
-    QTimer
-)
+from PyQt5.QtCore import Qt, QSize, QSettings, QTimer
 
-from PyQt5.QtWidgets import (
-    QListWidgetItem,
-    QListWidget,
-    QLabel,
-    QInputDialog
-)
+from PyQt5.QtWidgets import QListWidgetItem, QListWidget, QLabel, QInputDialog
 
 from qgis.utils import iface
 
@@ -42,7 +27,7 @@ from qgis.core import (
     QgsPoint,
     QgsVectorLayer,
     QgsWkbTypes,
-    QgsGeometry
+    QgsGeometry,
 )
 
 from qgis.gui import QgsRubberBand
@@ -52,7 +37,8 @@ from kadas.kadasgui import (
     KadasItemPos,
     KadasMapCanvasItemManager,
     KadasPluginInterface,
-    KadasGpxWaypointItem)
+    KadasGpxWaypointItem,
+)
 
 from kadasrouting.utilities import formatdist, pushMessage, iconPath
 from kadasrouting.core.optimalroutelayer import OptimalRouteLayer, NotInRouteException
@@ -62,7 +48,8 @@ from kadasrouting.utilities import tr
 
 LOG = logging.getLogger(__name__)
 
-route_html_template = '''
+route_html_template = (
+    """
 <table border="0" style="border-collapse: collapse; width: 100%; height: 100%;">
 <tbody>
 <tr>
@@ -74,56 +61,91 @@ route_html_template = '''
 </td>
 </tr>
 <tr>
-<td style="width: 100%; background-color: #adb9ca; text-align: left; font-size:12pt">''' + tr('Then') + '''
+<td style="width: 100%; background-color: #adb9ca; text-align: left; font-size:12pt">"""
+    + tr("Then")
+    + """
 <img src="{icon2}" width="32" height="32" />&nbsp;{dist2}<br/> {message2}</td>
 </tr>
 <tr>
 <td style="width: 100%; background-color: #44546a;">
 <p style="text-align: left;">
-<span style="color: #ffffff; font-size:10pt">''' + tr('Speed') + ''' {speed:.2f} km/h</span><br />
-<span style="color: #ffffff; font-size:10pt">''' + tr('Time Left') + ''' {timeleft}</span><br />
-<span style="color: #ffffff; font-size:10pt">''' + tr('Dist Left') + ''' {distleft}</span><br />
-<span style="color: #ffffff; font-size:10pt">''' + tr('ETA') + ''' {eta}</span></p>
-<p style="text-align: left;"><span style="color: #ffffff; font-size:10pt">''' + tr('My Position:') + '''</span><br />
+<span style="color: #ffffff; font-size:10pt">"""
+    + tr("Speed")
+    + """ {speed:.2f} km/h</span><br />
+<span style="color: #ffffff; font-size:10pt">"""
+    + tr("Time Left")
+    + """ {timeleft}</span><br />
+<span style="color: #ffffff; font-size:10pt">"""
+    + tr("Dist Left")
+    + """ {distleft}</span><br />
+<span style="color: #ffffff; font-size:10pt">"""
+    + tr("ETA")
+    + """ {eta}</span></p>
+<p style="text-align: left;"><span style="color: #ffffff; font-size:10pt">"""
+    + tr("My Position:")
+    + """</span><br />
 <span style="color: #ffffff;">{displayed_point}</span></p>
 </td>
 </tr>
 </tbody>
 </table>
-'''
+"""
+)
 
-waypoint_html_template = '''
+waypoint_html_template = (
+    """
 <table border="0" style="border-collapse: collapse; width: 100%; height: 100%;">
 <tbody>
 <tr>
 <td style="width: 100%; background-color: #44546a;">
 <p style="text-align: center;">
-<span style="color: yellow; font-size:14pt;">''' + tr('Ground Heading') + ''' </span>
+<span style="color: yellow; font-size:14pt;">"""
+    + tr("Ground Heading")
+    + """ </span>
 <span style="color: #ffffff;"> {heading:.0f}°</span><br/>
-<span style="color: #adb9ca; font-size:14pt;">''' + tr('WP Angle') + ''' </span>
+<span style="color: #adb9ca; font-size:14pt;">"""
+    + tr("WP Angle")
+    + """ </span>
 <span style="color: #ffffff;"> {wpangle:.0f}°</span><br />
-<span style="color: #ffffff;">''' + tr('Dist') + ''' {distleft}</span><br />
-<span style="color: #ffffff;">''' + tr('Speed') + ''' {speed:.2f} km/h</span><br />
-<span style="color: #ffffff;">''' + tr('ETA') + ''' {eta}</span></p>
+<span style="color: #ffffff;">"""
+    + tr("Dist")
+    + """ {distleft}</span><br />
+<span style="color: #ffffff;">"""
+    + tr("Speed")
+    + """ {speed:.2f} km/h</span><br />
+<span style="color: #ffffff;">"""
+    + tr("ETA")
+    + """ {eta}</span></p>
 </td>
 </tr>
 </tbody>
 </table>
-'''
+"""
+)
 
-waypoint_name_html_template = '<h3 style="text-align: center;"><span style="color: #ffffff;">{name}</span></h3>'
+waypoint_name_html_template = (
+    '<h3 style="text-align: center;"><span style="color: #ffffff;">{name}</span></h3>'
+)
 
-waypoint_miniature_html_template = '''
+waypoint_miniature_html_template = (
+    """
 <span style="color: white;">{name}<br/>
-<span style="font-size:8pt;">''' + tr('Dist') + ''' {dist} | {wpangle:.0f}°</span></span>
-'''
+<span style="font-size:8pt;">"""
+    + tr("Dist")
+    + """ {dist} | {wpangle:.0f}°</span></span>
+"""
+)
 
-waypoint_miniature_selected_html_template = '''
+waypoint_miniature_selected_html_template = (
+    """
 <span style="color: white; font-weight: bold; ">{name}<br/>
-<span style="font-size:8pt;">''' + tr('Dist') + ''' {dist} | {wpangle:.0f}°</span></span>
-'''
+<span style="font-size:8pt;">"""
+    + tr("Dist")
+    + """ {dist} | {wpangle:.0f}°</span></span>
+"""
+)
 
-message_html_template = '''
+message_html_template = """
 <table border="0" style="border-collapse: collapse; width: 100%;">
 <tbody>
 <tr>
@@ -133,7 +155,7 @@ message_html_template = '''
 </tr>
 </tbody>
 </table>
-'''
+"""
 
 WIDGET, BASE = uic.loadUiType(
     os.path.join(os.path.dirname(__file__), "navigationpanel.ui")
@@ -144,51 +166,53 @@ def getInstructionsToWaypoint(waypoint, gpsinfo):
     point = QgsPointXY(gpsinfo.longitude, gpsinfo.latitude)
     qgsdistance = QgsDistanceArea()
     qgsdistance.setSourceCrs(
-        QgsCoordinateReferenceSystem(4326), QgsProject.instance().transformContext())
+        QgsCoordinateReferenceSystem(4326), QgsProject.instance().transformContext()
+    )
     qgsdistance.setEllipsoid(qgsdistance.sourceCrs().ellipsoidAcronym())
     wpangle = math.degrees(qgsdistance.bearing(point, waypoint))
     dist = qgsdistance.convertLengthMeasurement(
-                                        qgsdistance.measureLine(waypoint, point),
-                                        QgsUnitTypes.DistanceMeters)
+        qgsdistance.measureLine(waypoint, point), QgsUnitTypes.DistanceMeters
+    )
 
     timeleft = dist / 1000 / gpsinfo.speed * 3600
     delta = datetime.timedelta(seconds=timeleft)
     eta = datetime.datetime.now() + delta
     eta_string = eta.strftime("%H:%M")
 
-    return {"heading": gpsinfo.direction,
-            "wpangle": wpangle,
-            "distleft": formatdist(dist),
-            "raw_distleft": dist,
-            "speed": gpsinfo.speed,
-            "eta": eta_string}
+    return {
+        "heading": gpsinfo.direction,
+        "wpangle": wpangle,
+        "distleft": formatdist(dist),
+        "raw_distleft": dist,
+        "speed": gpsinfo.speed,
+        "eta": eta_string,
+    }
 
 
-class NavigationFromWaypointsLayer():
+class NavigationFromWaypointsLayer:
     def __init__(self):
         self.crs = QgsCoordinateReferenceSystem(4326)
         itemRegex = {
-            'KadasGpxRouteItemRegex': r'^<MapItem(.*)name="KadasGpxRouteItem"(.*)CDATA(.*)]><\/MapItem>',
-            'KadasGpxWaypointItemRegex': r'^<MapItem(.*)name="KadasGpxWaypointItem"(.*)CDATA(.*)]><\/MapItem>'
+            "KadasGpxRouteItemRegex": r'^<MapItem(.*)name="KadasGpxRouteItem"(.*)CDATA(.*)]><\/MapItem>',
+            "KadasGpxWaypointItemRegex": r'^<MapItem(.*)name="KadasGpxWaypointItem"(.*)CDATA(.*)]><\/MapItem>',
         }
         orig_project = {
-            'filename': QgsProject.instance().fileName(),
+            "filename": QgsProject.instance().fileName(),
         }
-        tmp_file = tempfile.NamedTemporaryFile(suffix = '.qgz')
-
+        tmp_file = tempfile.NamedTemporaryFile(suffix=".qgz")
         QgsProject.instance().setFileName(tmp_file.name)
         QgsProject.instance().write()
 
         # parse project
         with ZipFile(tmp_file.name) as qgzPrj:
-            prjName = [x for x in qgzPrj.namelist() if 'qgs' in x][0]
-            project_contents = str(qgzPrj.read(prjName)).split('\\n')
+            prjName = [x for x in qgzPrj.namelist() if "qgs" in x][0]
+            project_contents = str(qgzPrj.read(prjName)).split("\\n")
 
         self.mapItems = []
         for i in project_contents:
-            if 'MapItem' in i:
+            if "MapItem" in i:
                 for k, v in itemRegex.items():
-                    if k == 'KadasGpxRouteItemRegex':
+                    if k == "KadasGpxRouteItemRegex":
                         # TODO: this is a placeholder if we must implement the
                         # feature also for route items and not only for Waypoint Items
                         # we'll need to differentiate the routes computed with valhalla from
@@ -196,22 +220,23 @@ class NavigationFromWaypointsLayer():
                         continue
                     catched = re.match(itemRegex[k], i.strip())
                     if catched:
-                        self.mapItems.append(self._create_gpx_waypoints(json.loads(catched[3]), k))
-        QgsProject.instance().setFileName(orig_project['filename'])
-
+                        self.mapItems.append(
+                            self._create_gpx_waypoints(json.loads(catched[3]), k)
+                        )
+        QgsProject.instance().setFileName(orig_project["filename"])
 
     def _create_gpx_waypoints(self, map_item, key):
         item = KadasGpxWaypointItem()
-        if key == 'KadasGpxWaypointItemRegex':
-            p = map_item[0]['state']['points'][0]
+        if key == "KadasGpxWaypointItemRegex":
+            p = map_item[0]["state"]["points"][0]
             item.addPartFromGeometry(QgsPoint(p[0], p[1]))
-        elif key == 'KadasGpxRouteItemRegex':
+        elif key == "KadasGpxRouteItemRegex":
             # FIXME: this will need more stuff to work, for the routes we must
             # add a way to track the passed waypoints, and use the layer internal points
             # as polyline instead
-            for p in map_item[0]['state']['points'][0]:
+            for p in map_item[0]["state"]["points"][0]:
                 item.addPartFromGeometry(QgsPoint(p[0], p[1]))
-        item.setName(map_item[0]['props']['name'])
+        item.setName(map_item[0]["props"]["name"])
         return item
 
     def items(self):
@@ -251,12 +276,15 @@ class NavigationPanel(BASE, WIDGET):
         self.labelConfigureWarnings.linkActivated.connect(self.configureWarnings)
 
     def configureWarnings(self, url):
-        threshold = QSettings().value("kadasrouting/warningThreshold", self.WARNING_DISTANCE, type=int)
+        threshold = QSettings().value(
+            "kadasrouting/warningThreshold", self.WARNING_DISTANCE, type=int
+        )
         value, ok = QInputDialog.getInt(
             self.iface.mainWindow(),
             self.tr("Navigation"),
             self.tr("Set threshold for warnings (meters)"),
-            threshold)
+            threshold,
+        )
         if ok:
             QSettings().setValue("kadasrouting/warningThreshold", value)
 
@@ -285,7 +313,7 @@ class NavigationPanel(BASE, WIDGET):
             self.setMessage(self.tr("Cannot connect to GPS"))
             return
         layer = self.iface.activeLayer()
-        LOG.debug('Debug: type(layer) = {}'.format(type(layer)))
+        LOG.debug("Debug: type(layer) = {}".format(type(layer)))
         point = QgsPointXY(gpsinfo.longitude, gpsinfo.latitude)
         origCrs = QgsCoordinateReferenceSystem(4326)
         canvasCrs = self.iface.mapCanvas().mapSettings().destinationCrs()
@@ -301,7 +329,10 @@ class NavigationPanel(BASE, WIDGET):
         self.iface.mapCanvas().refresh()
         self.rubberband.reset(QgsWkbTypes.LineGeometry)
 
-        if isinstance(layer, QgsVectorLayer) and layer.geometryType() == QgsWkbTypes.LineGeometry:
+        if (
+            isinstance(layer, QgsVectorLayer)
+            and layer.geometryType() == QgsWkbTypes.LineGeometry
+        ):
             feature = next(layer.getFeatures(), None)
             if feature:
                 geom = feature.geometry()
@@ -311,7 +342,7 @@ class NavigationPanel(BASE, WIDGET):
                     rubbergeom.transform(transform)
                     self.rubberband.setToGeometry(rubbergeom)
 
-        if hasattr(layer, 'valhalla') and layer.hasRoute():
+        if hasattr(layer, "valhalla") and layer.hasRoute():
             try:
                 maneuver = layer.maneuverForPoint(point, gpsinfo.speed)
                 LOG.debug(maneuver)
@@ -325,8 +356,10 @@ class NavigationPanel(BASE, WIDGET):
             self.setWarnings(maneuver["raw_distleft"])
         # FIXME: we could have some better way of differentiating this...
         elif not isinstance(layer, type(None)):
-            if layer.name() != 'Routes':
-                self.setMessage(self.tr("Select a route or waypoint layer for navigation"))
+            if layer.name() != "Routes":
+                self.setMessage(
+                    self.tr("Select a route or waypoint layer for navigation")
+                )
                 self.stopNavigation()
                 return
             waypoints = self.waypointsFromLayer(self.navLayer)
@@ -336,14 +369,20 @@ class NavigationPanel(BASE, WIDGET):
                     self.populateWaypoints(waypoints)
                 else:
                     self.updateWaypoints()
-                waypointItem = self.listWaypoints.currentItem() or self.listWaypoints.item(0)
+                waypointItem = (
+                    self.listWaypoints.currentItem() or self.listWaypoints.item(0)
+                )
                 waypoint = waypointItem.point
                 instructions = getInstructionsToWaypoint(waypoint, gpsinfo)
                 self.setCompass(instructions["heading"], instructions["wpangle"])
                 html = waypoint_html_template.format(**instructions)
                 self.textBrowser.setHtml(html)
-                self.textBrowser.setFixedHeight(self.textBrowser.document().size().height())
-                self.labelWaypointName.setText(waypoint_name_html_template.format(name=waypointItem.name))
+                self.textBrowser.setFixedHeight(
+                    self.textBrowser.document().size().height()
+                )
+                self.labelWaypointName.setText(
+                    waypoint_name_html_template.format(name=waypointItem.name)
+                )
                 self.setWidgetsVisibility(True)
                 self.setWarnings(instructions["raw_distleft"])
             else:
@@ -356,9 +395,19 @@ class NavigationPanel(BASE, WIDGET):
             return
 
     def setWarnings(self, dist):
-        threshold = QSettings().value("kadasrouting/warningThreshold", self.WARNING_DISTANCE, type=int)
-        if (self.chkShowWarnings.isChecked() and not self.warningShown and dist < threshold):
-            pushMessage(self.tr("In {dist} meters you will arrive at your destination").format(dist=int(dist)))
+        threshold = QSettings().value(
+            "kadasrouting/warningThreshold", self.WARNING_DISTANCE, type=int
+        )
+        if (
+            self.chkShowWarnings.isChecked()
+            and not self.warningShown
+            and dist < threshold
+        ):
+            pushMessage(
+                self.tr("In {dist} meters you will arrive at your destination").format(
+                    dist=int(dist)
+                )
+            )
             self.warningShown = True
 
     def getOptimalRouteLayerForGeometry(self, geom):
@@ -371,10 +420,12 @@ class NavigationPanel(BASE, WIDGET):
             self.iface.mainWindow(),
             self.tr("Navigation"),
             self.tr("Select Vehicle to use with layer '{name}'").format(name=name),
-            vehicles.vehicle_reduced_names())
+            vehicles.vehicle_reduced_names(),
+        )
         if ok:
             profile, costingOptions = vehicles.options_for_vehicle_reduced(
-                vehicles.vehicle_reduced_names().index(value))
+                vehicles.vehicle_reduced_names().index(value)
+            )
             layer = OptimalRouteLayer("")
             try:
                 if geom.isMultipart():
@@ -403,7 +454,7 @@ class NavigationPanel(BASE, WIDGET):
         painter.drawPixmap(0, 0, self.FIXED_WIDTH, self.FIXED_WIDTH, compassPixmap)
         transform = QTransform()
         transform.translate(self.FIXED_WIDTH / 2, self.FIXED_WIDTH / 2)
-        transform.rotate(wpangle-heading)
+        transform.rotate(wpangle - heading)
         transform.translate(-self.FIXED_WIDTH / 2, -self.FIXED_WIDTH / 2)
         painter.setTransform(transform)
         painter.drawPixmap(0, 0, self.FIXED_WIDTH, self.FIXED_WIDTH, bearingPixmap)
@@ -423,7 +474,7 @@ class NavigationPanel(BASE, WIDGET):
 
     def waypointsFromLayer(self, layer):
         try:
-            '''
+            """
             center = iface.mapCanvas().center()
             outCrs = QgsCoordinateReferenceSystem(4326)
             canvasCrs = iface.mapCanvas().mapSettings().destinationCrs()
@@ -439,8 +490,10 @@ class NavigationPanel(BASE, WIDGET):
             item3.addPartFromGeometry(QgsPoint(wgspoint.x() + 10, wgspoint.y() + 10))
             item3.setName("My Waypoint")
             return [item, item2, item3]
-            '''
-            return [item for item in layer.items() if isinstance(item, KadasGpxWaypointItem)]
+            """
+            return [
+                item for item in layer.items() if isinstance(item, KadasGpxWaypointItem)
+            ]
         except Exception as e:
             LOG.warning(e)
             return []
@@ -450,7 +503,9 @@ class NavigationPanel(BASE, WIDGET):
         self.waypointWidgets = []
         for waypoint in waypoints:
             item = WaypointItem(waypoint)
-            widget = WaypointItemWidget(waypoint, self.gpsConnection.currentGPSInformation())
+            widget = WaypointItemWidget(
+                waypoint, self.gpsConnection.currentGPSInformation()
+            )
             self.listWaypoints.addItem(item)
             item.setSizeHint(widget.sizeHint())
             self.listWaypoints.setItemWidget(item, widget)
@@ -478,12 +533,16 @@ class NavigationPanel(BASE, WIDGET):
         self.setMessage(self.tr("Connecting to GPS..."))
         self.gpsConnection = getGpsConnection()
         try:
-            if iface.activeLayer().name() == 'Routes':
+            if iface.activeLayer().name() == "Routes":
                 self.navLayer = NavigationFromWaypointsLayer()
         except AttributeError:
             pass
         except FileNotFoundError:
-            self.setMessage(self.tr("You must save your project to use waypoint layers for navigation"))
+            self.setMessage(
+                self.tr(
+                    "You must save your project to use waypoint layers for navigation"
+                )
+            )
             return
         except TypeError:
             self.setMessage(self.tr("There are no waypoints in the 'Routes' layer"))
@@ -501,7 +560,9 @@ class NavigationPanel(BASE, WIDGET):
             )
             # For some reason the first time shown, the direction of the center pin is following the map canvas.
             # The line below is needed to neutralize the direction of the center pin (to make it points up)
-            self.centerPin.setAngle(-self.gpsConnection.currentGPSInformation().direction)
+            self.centerPin.setAngle(
+                -self.gpsConnection.currentGPSInformation().direction
+            )
             KadasMapCanvasItemManager.addItem(self.centerPin)
             self.updateNavigationInfo()
             self.timer.start(1000)
@@ -527,7 +588,9 @@ class NavigationPanel(BASE, WIDGET):
             # centerPin might have been deleted
             pass
         try:
-            self.iface.layerTreeView().currentLayerChanged.disconnect(self.currentLayerChanged)
+            self.iface.layerTreeView().currentLayerChanged.disconnect(
+                self.currentLayerChanged
+            )
         except TypeError as e:
             LOG.debug(e)
         # Finally, reset everything
@@ -537,7 +600,6 @@ class NavigationPanel(BASE, WIDGET):
 
 
 class WaypointItem(QListWidgetItem):
-
     def __init__(self, waypoint):
         super().__init__(waypoint.name())
         pos = waypoint.position()
@@ -546,7 +608,6 @@ class WaypointItem(QListWidgetItem):
 
 
 class WaypointItemWidget(QLabel):
-
     def __init__(self, waypoint, gpsinfo):
         super().__init__()
         self.setMargin(4)
@@ -560,11 +621,18 @@ class WaypointItemWidget(QLabel):
         pos = self.waypoint.position()
         point = QgsPointXY(pos.x(), pos.y())
         instructions = getInstructionsToWaypoint(point, gpsinfo)
-        template = waypoint_miniature_selected_html_template if self.selected else waypoint_miniature_html_template
-        self.setText(template.format(
+        template = (
+            waypoint_miniature_selected_html_template
+            if self.selected
+            else waypoint_miniature_html_template
+        )
+        self.setText(
+            template.format(
                 name=self.waypoint.name(),
                 wpangle=instructions["wpangle"],
-                dist=instructions["distleft"]))
+                dist=instructions["distleft"],
+            )
+        )
         return
 
     def setIsItemSelected(self, selected):

--- a/kadasrouting/gui/navigationpanel.py
+++ b/kadasrouting/gui/navigationpanel.py
@@ -226,7 +226,8 @@ class NavigationFromWaypointsLayer:
         try:
             os.remove(tmp_file.name)
         except FileNotFoundError:
-            pass # if the file is not there we don't worry
+            # if the file is not there we don't worry
+            pass
 
     def _create_gpx_waypoints(self, map_item, key):
         item = KadasGpxWaypointItem()

--- a/kadasrouting/gui/navigationpanel.py
+++ b/kadasrouting/gui/navigationpanel.py
@@ -207,7 +207,6 @@ class NavigationFromWaypointsLayer:
         with ZipFile(tmp_file.name) as qgzPrj:
             prjName = [x for x in qgzPrj.namelist() if "qgs" in x][0]
             project_contents = str(qgzPrj.read(prjName)).split("\\n")
-
         self.mapItems = []
         for i in project_contents:
             if "MapItem" in i:
@@ -224,6 +223,10 @@ class NavigationFromWaypointsLayer:
                             self._create_gpx_waypoints(json.loads(catched[3]), k)
                         )
         QgsProject.instance().setFileName(orig_project["filename"])
+        try:
+            os.remove(tmp_file.name)
+        except FileNotFoundError:
+            pass # if the file is not there we don't worry
 
     def _create_gpx_waypoints(self, map_item, key):
         item = KadasGpxWaypointItem()

--- a/kadasrouting/gui/navigationpanel.py
+++ b/kadasrouting/gui/navigationpanel.py
@@ -465,7 +465,6 @@ class NavigationPanel(BASE, WIDGET):
 
         self.setMessage(self.tr("Connecting to GPS..."))
         self.gpsConnection = getGpsConnection()
-        # FIXME: should not initialize this if unused
         try:
             if iface.activeLayer().name() == 'Routes':
                 self.navLayer = NavigationFromWaypointsLayer()


### PR DESCRIPTION
This PR adds the support of the "navigate from waypoints" layer. It is a workaround for the pyqt5 problem where a KadasItemLayer does not provide an `items()` method.

It requires the user to save his project, and then parses the project XML file to retrieve the MapItem entries.